### PR TITLE
Fixed wrong function name

### DIFF
--- a/lib/commands/supplyTemperature.js
+++ b/lib/commands/supplyTemperature.js
@@ -1,4 +1,4 @@
-module.exports = function pressure() {
+module.exports = function supplyTemperature() {
   return this.get('/heatingCircuits/hc1/actualSupplyTemperature').then((r) => {
     return { temperature : r.value, unit : r.unitOfMeasure };
   });


### PR DESCRIPTION
The function name in the file was probably copied over from pressure.js, changed it to match supplyTemperature.
