### PR TITLE
User more proper way of detecting placeholder gas usage entries

### DIFF
--- a/lib/commands/gasUsage.js
+++ b/lib/commands/gasUsage.js
@@ -6,7 +6,7 @@ module.exports = function gasUsage(page) {
   return p.then((page) => {
     return this.get('/ecus/rrc/recordings/gasusage?page=' + page);
   }).then((data) => {
-    return data.value.filter((v) => v.T !== -1).map((v) => {
+    return data.value.filter((v) => v.d !== "255-256-65535").map((v) => {
       var m = v.d.match(/^(\d{2})-(\d{2})-(\d{4})$/);
       return {
         date                          : new Date(m[3], m[2] - 1, m[1]),


### PR DESCRIPTION
-1 is a perfectly valid temperature while 255-256-65535 is not a valid
date in any case. I've had 4 entries with T == -1 for the last year and
they were getting filtered away.